### PR TITLE
Tidy closed sockets from listeners event loop

### DIFF
--- a/lib/net/ssh/connection/session.rb
+++ b/lib/net/ssh/connection/session.rb
@@ -205,6 +205,12 @@ module Net; module SSH; module Connection
     def process(wait=nil, &block)
       return false unless preprocess(&block)
 
+      listeners.each do |io, _|
+        if (io.is_a?(::TCPSocket) && io.inspect.to_s =~ /closed/)
+          listeners.delete(io)
+        end
+      end
+      
       r = listeners.keys
       w = r.select { |w2| w2.respond_to?(:pending_write?) && w2.pending_write? }
       readers, writers, = Net::SSH::Compat.io_select(r, w, nil, io_select_wait(wait))


### PR DESCRIPTION
This is related to https://github.com/net-ssh/net-ssh-gateway/issues/4. I traced the problem to Net::SSH::Compat.io_select which hangs indefinitely when it encounters a closed socket.. which occurs in forward.rb:L94 when the on_open_failed closes the socket. Not sure if this is best place to fix but checking for sockets that are closed and getting rid of them before calling io_select, it fixed the problem i had.
